### PR TITLE
Remove 'volume' from return dict

### DIFF
--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -22,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CLOSE = 'close'
 ATTR_HIGH = 'high'
 ATTR_LOW = 'low'
-ATTR_VOLUME = 'volume'
 
 CONF_ATTRIBUTION = "Stock market information provided by Alpha Vantage"
 CONF_FOREIGN_EXCHANGE = 'foreign_exchange'
@@ -148,7 +147,6 @@ class AlphaVantageSensor(Entity):
                 ATTR_CLOSE: self.values['4. close'],
                 ATTR_HIGH: self.values['2. high'],
                 ATTR_LOW: self.values['3. low'],
-                ATTR_VOLUME: self.values['5. volume'],
             }
 
     @property


### PR DESCRIPTION
## Description:
https://github.com/home-assistant/home-assistant/issues/15271

intraday results do not return the volume. See https://www.alphavantage.co/documentation/#intraday

**Related issue (if applicable):** fixes #15271

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
